### PR TITLE
Fixed unexpected call to "map" function on content

### DIFF
--- a/node-theseus.js
+++ b/node-theseus.js
@@ -153,7 +153,7 @@ exports.beginInstrumentation = function (options) {
 				generatedFilename: newFilename,
 			});
 
-			var map = content.map().toString();
+			var map = typeof content.map !== 'undefined' ? content.map().toString() : false;
 			if (map) {
 				maps[newFilename] = map;
 			}


### PR DESCRIPTION
Added type check before call to map function..

This problem was occurring to me: 

TypeError: Property 'map' of object is not a function 
at Object.Module._extensions..js (/usr/local/lib/node_modules/node-theseus/node-theseus.js:156:22)
